### PR TITLE
Transfer schema refactor and minor fixes

### DIFF
--- a/dsp-schemas/src/main/resources/catalog/dataset-schema.json
+++ b/dsp-schemas/src/main/resources/catalog/dataset-schema.json
@@ -74,12 +74,7 @@
               "type": "string"
             },
             {
-              "$ref": "#/definitions/DataService",
-              "not": {
-                "required": [
-                  "servesDataset"
-                ]
-              }
+              "$ref": "#/definitions/DataService"
             }
           ]
         },

--- a/dsp-schemas/src/main/resources/context/dspace.jsonld
+++ b/dsp-schemas/src/main/resources/context/dspace.jsonld
@@ -45,8 +45,6 @@
         "@protected": true,
         "@import": "http://www.w3.org/dspace-odrl/odrl.jsonld",
         "@propagate": true,
-        "uid": null,
-        "type": null,
         "callbackAddress": "dspace:callbackAddress",
         "providerPid": {
           "@type": "@id",
@@ -69,8 +67,6 @@
         "@protected": true,
         "@import": "http://www.w3.org/dspace-odrl/odrl.jsonld",
         "@propagate": true,
-        "uid": null,
-        "type": null,
         "callbackAddress": "dspace:callbackAddress",
         "providerPid": {
           "@type": "@id",
@@ -93,8 +89,6 @@
         "@protected": true,
         "@import": "http://www.w3.org/dspace-odrl/odrl.jsonld",
         "@propagate": true,
-        "uid": null,
-        "type": null,
         "providerPid": {
           "@type": "@id",
           "@id": "dspace:providerPid"
@@ -400,8 +394,6 @@
         "@protected": true,
         "@import": "http://www.w3.org/dspace-odrl/odrl.jsonld",
         "@propagate": true,
-        "uid": null,
-        "type": null,
         "distribution": {
           "@id": "dcat:distribution",
           "@container": "@set"

--- a/dsp-schemas/src/main/resources/negotiation/contract-offer-message-schema.json
+++ b/dsp-schemas/src/main/resources/negotiation/contract-offer-message-schema.json
@@ -32,11 +32,15 @@
             },
             {
               "properties": {
+                "@id": {
+                  "type": "string"
+                },
                 "target": {
                   "type": "string"
                 }
               },
               "required": [
+                "@id",
                 "target"
               ]
             }

--- a/dsp-schemas/src/main/resources/transfer/data-address-schema.json
+++ b/dsp-schemas/src/main/resources/transfer/data-address-schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "TransferSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/DataAddress"
+    }
+  ],
+  "$id": "https://w3id.org/dspace/2024/1/transfer/transfer-schema.json",
+  "definitions": {
+    "DataAddress": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string",
+          "const": "DataAddress"
+        },
+        "endpointType": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "endpointProperties": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@type": {
+                "type": "string",
+                "const": "EndpointProperty"
+              },
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "@type",
+              "name",
+              "value"
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "@type",
+        "endpointType",
+        "endpoint"
+      ]
+    }
+  }
+}

--- a/dsp-schemas/src/main/resources/transfer/transfer-error-schema.json
+++ b/dsp-schemas/src/main/resources/transfer/transfer-error-schema.json
@@ -10,29 +10,22 @@
   "$id": "https://w3id.org/dspace/2024/1/transfer/transfer-error-schema.json",
   "definitions": {
     "TransferError": {
-      "type": "object",
-      "properties": {
-        "@context": {
-          "$ref": "https://w3id.org/dspace/2024/1/common/context-schema.json"
+      "allOf": [
+        {
+          "$ref": "https://w3id.org/dspace/2024/1/transfer/transfer-schema.json#definitions/AbstractTransferCodeMessage"
         },
-        "@type": {
-          "type": "string",
-          "const": "TransferError"
-        },
-        "providerPid": {
-          "type": "string"
-        },
-        "consumerPid": {
-          "type": "string"
-        },
-        "code": {
-          "type": "string"
-        },
-        "reason": {
-          "type": "array",
-          "items": {}
+        {
+          "properties": {
+            "@type": {
+              "type": "string",
+              "const": "TransferError"
+            }
+          },
+          "required": [
+            "@type"
+          ]
         }
-      },
+      ],
       "required": [
         "@context",
         "@type",

--- a/dsp-schemas/src/main/resources/transfer/transfer-request-message-schema.json
+++ b/dsp-schemas/src/main/resources/transfer/transfer-request-message-schema.json
@@ -26,7 +26,7 @@
           "type": "string"
         },
         "dataAddress": {
-          "$ref": "https://w3id.org/dspace/2024/1/transfer/transfer-schema.json"
+          "$ref": "https://w3id.org/dspace/2024/1/transfer/data-address-schema.json"
         },
         "callbackAddress": {
           "type": "string"

--- a/dsp-schemas/src/main/resources/transfer/transfer-schema.json
+++ b/dsp-schemas/src/main/resources/transfer/transfer-schema.json
@@ -4,7 +4,7 @@
   "type": "object",
   "allOf": [
     {
-      "$ref": "#/definitions/DataAddress"
+      "$ref": "#/definitions/AbstractTransferCodeMessage"
     }
   ],
   "$id": "https://w3id.org/dspace/2024/1/transfer/transfer-schema.json",
@@ -35,49 +35,6 @@
         "@context",
         "providerPid",
         "consumerPid"
-      ]
-    },
-    "DataAddress": {
-      "type": "object",
-      "properties": {
-        "@type": {
-          "type": "string",
-          "const": "DataAddress"
-        },
-        "endpointType": {
-          "type": "string"
-        },
-        "endpoint": {
-          "type": "string"
-        },
-        "endpointProperties": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "@type": {
-                "type": "string",
-                "const": "EndpointProperty"
-              },
-              "name": {
-                "type": "string"
-              },
-              "value": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "@type",
-              "name",
-              "value"
-            ]
-          }
-        }
-      },
-      "required": [
-        "@type",
-        "endpointType",
-        "endpoint"
       ]
     }
   }

--- a/dsp-schemas/src/main/resources/transfer/transfer-start-message-schema.json
+++ b/dsp-schemas/src/main/resources/transfer/transfer-start-message-schema.json
@@ -26,7 +26,7 @@
           "type": "string"
         },
         "dataAddress": {
-          "$ref": "https://w3id.org/dspace/2024/1/transfer/transfer-schema.json"
+          "$ref": "https://w3id.org/dspace/2024/1/transfer/data-address-schema.json"
         }
       },
       "required": [

--- a/dsp-schemas/src/test/java/com/metaformsystems/dsp/schema/transfer/TransferSchemaTest.java
+++ b/dsp-schemas/src/test/java/com/metaformsystems/dsp/schema/transfer/TransferSchemaTest.java
@@ -31,7 +31,7 @@ public class TransferSchemaTest extends AbstractSchemaTest {
 
     @BeforeEach
     void setUp() {
-        setUp("/transfer/transfer-schema.json");
+        setUp("/transfer/data-address-schema.json");
     }
 
 


### PR DESCRIPTION
Separates DataAddres from transfer-schema.json into data-address-schema.json
Removes unnecessary ODRL context resets for `uid` and `type`
Adds required `@id` for offers in `ContractOfferMessage`
Simplifies `TransferError` by using `AbstractTransferCodeMessage`
